### PR TITLE
Make connecting smoother

### DIFF
--- a/examples/postgres.rs
+++ b/examples/postgres.rs
@@ -1,6 +1,7 @@
 use bevy::{ecs::system::SystemId, prelude::*};
 use bevy_realtime::{
     channel::ChannelBuilder,
+    client::ConnectError,
     message::{
         payload::{PostgresChangesEvent, PostgresChangesPayload},
         postgres_change_filter::PostgresChangeFilter,
@@ -26,10 +27,11 @@ fn main() {
 
 fn setup(world: &mut World) {
     world.spawn(Camera2dBundle::default());
-
+    let connect_callback = world.register_system(connect_callback);
     let build_channel_callback = world.register_system(build_channel_callback);
+
     let client = world.resource::<Client>();
-    let _ = client.connect();
+    let _ = client.connect(connect_callback);
     client.channel(build_channel_callback).unwrap();
 
     let on_change_callback = world.register_system(on_change_callback);
@@ -58,4 +60,15 @@ fn build_channel_callback(
 
 fn on_change_callback(input: In<PostgresChangesPayload>) {
     println!("Change got! {:?}", *input);
+}
+
+fn connect_callback(In(result): In<Result<(), ConnectError>>) {
+    match result {
+        Ok(()) => {
+            info!("Connection is live!");
+        }
+        Err(e) => {
+            error!("Connection failed! {:?}", e);
+        }
+    }
 }

--- a/examples/postgres.rs
+++ b/examples/postgres.rs
@@ -29,6 +29,7 @@ fn setup(world: &mut World) {
 
     let build_channel_callback = world.register_system(build_channel_callback);
     let client = world.resource::<Client>();
+    let _ = client.connect();
     client.channel(build_channel_callback).unwrap();
 
     let on_change_callback = world.register_system(on_change_callback);

--- a/examples/postgres_authed.rs
+++ b/examples/postgres_authed.rs
@@ -38,6 +38,7 @@ fn setup(world: &mut World) {
 
     let callback = world.register_system(build_channel_callback);
     let client = world.resource::<RealtimeClient>();
+    let _ = client.connect();
     client.channel(callback).unwrap();
 
     let on_change_callback = world.register_system(on_change_callback);

--- a/examples/postgres_authed.rs
+++ b/examples/postgres_authed.rs
@@ -3,6 +3,7 @@ use bevy_gotrue::{just_logged_in, AuthCreds, AuthPlugin, Client as AuthClient};
 use bevy_http_client::HttpClientPlugin;
 use bevy_realtime::{
     channel::ChannelBuilder,
+    client::ConnectError,
     message::{
         payload::{PostgresChangesEvent, PostgresChangesPayload},
         postgres_change_filter::PostgresChangeFilter,
@@ -36,10 +37,12 @@ fn main() {
 fn setup(world: &mut World) {
     world.spawn(Camera2dBundle::default());
 
-    let callback = world.register_system(build_channel_callback);
+    let build_channel_callback = world.register_system(build_channel_callback);
+    let connect_callback = world.register_system(connect_callback);
+
     let client = world.resource::<RealtimeClient>();
-    let _ = client.connect();
-    client.channel(callback).unwrap();
+    let _ = client.connect(connect_callback);
+    client.channel(build_channel_callback).unwrap();
 
     let on_change_callback = world.register_system(on_change_callback);
     world.insert_resource(OnChangeCallback(on_change_callback));
@@ -83,4 +86,15 @@ fn signed_in(client: Res<RealtimeClient>, auth: Res<AuthClient>) {
 
 fn on_change_callback(input: In<PostgresChangesPayload>) {
     println!("Change got! {:?}", *input);
+}
+
+fn connect_callback(In(result): In<Result<(), ConnectError>>) {
+    match result {
+        Ok(()) => {
+            info!("Connection is live!");
+        }
+        Err(e) => {
+            error!("Connection failed! {:?}", e);
+        }
+    }
 }

--- a/examples/presence.rs
+++ b/examples/presence.rs
@@ -3,6 +3,7 @@ use std::{collections::HashMap, time::Duration};
 use bevy::{ecs::system::SystemId, prelude::*, time::common_conditions::on_timer};
 use bevy_realtime::{
     channel::ChannelBuilder,
+    client::ConnectError,
     message::payload::PresenceConfig,
     presence::{PrescenceTrack, PresenceEvent, PresenceState},
     BevyChannelBuilder, BuildChannel, Channel, Client, RealtimePlugin,
@@ -35,8 +36,10 @@ fn setup(world: &mut World) {
     world.spawn(Camera2dBundle::default());
 
     let build_channel_callback = world.register_system(build_channel_callback);
+    let connect_callback = world.register_system(connect_callback);
+
     let client = world.resource::<Client>();
-    let _ = client.connect();
+    let _ = client.connect(connect_callback);
     client.channel(build_channel_callback).unwrap();
 
     let get_presence_state_callback = world.register_system(get_presence_state_callback);
@@ -81,4 +84,15 @@ fn get_presence_state_callback(state: In<PresenceState>) {
 
 fn presence_join_callback(In((id, state, joins)): In<(String, PresenceState, PresenceState)>) {
     println!("{}|{:?}|{:?}", id, state, joins);
+}
+
+fn connect_callback(In(result): In<Result<(), ConnectError>>) {
+    match result {
+        Ok(()) => {
+            info!("Connection is live!");
+        }
+        Err(e) => {
+            error!("Connection failed! {:?}", e);
+        }
+    }
 }

--- a/examples/presence.rs
+++ b/examples/presence.rs
@@ -36,6 +36,7 @@ fn setup(world: &mut World) {
 
     let build_channel_callback = world.register_system(build_channel_callback);
     let client = world.resource::<Client>();
+    let _ = client.connect();
     client.channel(build_channel_callback).unwrap();
 
     let get_presence_state_callback = world.register_system(get_presence_state_callback);

--- a/src/client.rs
+++ b/src/client.rs
@@ -526,7 +526,7 @@ impl Client {
         }
 
         loop {
-            match self.next_message() {
+            match self.step() {
                 Ok(channel_ids) => {
                     debug!(
                         "[Blocking Subscribe] Message forwarded to {:?}",
@@ -582,7 +582,7 @@ impl Client {
     }
 
     /// The main step function for driving the [RealtimeClient]
-    pub fn next_message(&mut self) -> Result<Vec<Uuid>, NextMessageError> {
+    pub fn step(&mut self) -> Result<Vec<Uuid>, NextMessageError> {
         // TODO run manager_recv fns until channels drained
         match self.manager_recv() {
             Ok(()) => {}
@@ -692,7 +692,7 @@ impl Client {
 
         // wait until inbound_rx is drained
         loop {
-            let recv = self.next_message();
+            let recv = self.step();
 
             if Err(NextMessageError::WouldBlock) == recv {
                 break;
@@ -700,7 +700,7 @@ impl Client {
         }
 
         loop {
-            let _ = self.next_message();
+            let _ = self.step();
 
             let mut all_channels_closed = true;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -168,15 +168,10 @@ fn run_callbacks(
 pub fn client_ready(
     mut evr: EventReader<ConnectionState>,
     mut last_state: Local<ConnectionState>,
-    mut rate_limiter: Local<usize>,
     client: Res<Client>,
     sender: Res<CrossbeamEventSender<ConnectionState>>,
 ) -> bool {
-    *rate_limiter += 1;
-    if *rate_limiter % 30 == 0 {
-        *rate_limiter = 0;
-        client.connection_state(sender.clone()).unwrap_or(());
-    }
+    client.connection_state(sender.clone()).unwrap_or(());
 
     for ev in evr.read() {
         *last_state = *ev;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -111,7 +111,7 @@ impl Plugin for RealtimePlugin {
         // Start off thread client
         let _thread = std::thread::spawn(move || {
             loop {
-                match client.next_message() {
+                match client.step() {
                     Err(NextMessageError::WouldBlock) => {}
                     Ok(_) => {}
                     Err(_e) => {} //error!("{}", _e),


### PR DESCRIPTION
Moves `connect()` to `ClientManager` for use in userspace, which allows for delayed connection and connection retrying.

Adds a callback to the `connect()` function to make error messages pass back down the stack.

Renames some functions and variables for clarity.

Closes #4 